### PR TITLE
Add name to ConfigurableContainers-Core

### DIFF
--- a/ConfigurableContainers-Core.netkan
+++ b/ConfigurableContainers-Core.netkan
@@ -1,6 +1,7 @@
 {
     "spec_version" : "v1.4",
     "identifier"   : "ConfigurableContainers-Core",
+    "name"         : "Configurable Containers Core",
     "$kref"        : "#/ckan/spacedock/1002",
     "abstract"     : "This is the core configuration for the Configurable Containers.",
     "author"       : [ "allista" ],


### PR DESCRIPTION
ConfigurableContainers and ConfigurableContainers-Core have the same name, this fixes it.

Fixes https://github.com/KSP-CKAN/NetKAN/issues/4843
Fixes https://github.com/KSP-CKAN/NetKAN/pull/4797
