### PR TITLE
Added patch for OPT Spaceplane Parts

### DIFF
--- a/GameData/ConfigurableContainers/Parts/OPT_Patch.cfg
+++ b/GameData/ConfigurableContainers/Parts/OPT_Patch.cfg
@@ -1,0 +1,43 @@
+// ConfigurableContainers patch for OPT Spaceplane Parts
+//
+// conversion rate is 0.013717 m3/u of LF in LFO mix
+
+// Stock fuels with Firespitter fuel switch
+@PART[*]:HAS[#tags[*OPT*],@MODULE[FSfuelSwitch]]:FOR[ConfigurableContainers]:NEEDS[OPT]
+{
+    MODULE
+    {
+        name = ModuleTankManager
+        Volume = #$../MODULE[FSfuelSwitch]/resourceAmounts[1,;]$
+        @Volume *= 0.5
+        @Volume *= 0.013717
+        DoCostPatch = True
+        DoMassPatch = True
+        TANK
+        {
+            name = LFO
+            Volume = 100.0
+        }
+    }
+	!MODULE[FSfuelSwitch] {}
+}
+
+// Stock fuels without Firespitter fuel switch
+@PART[*]:HAS[#tags[*OPT*],@RESOURCE[LiquidFuel],@RESOURCE[Oxidizer]]:FOR[ConfigurableContainers]:NEEDS[OPT]
+{
+    MODULE
+    {
+        name = ModuleTankManager
+        Volume = #$../RESOURCE[LiquidFuel]/amount$
+        @Volume *= 0.013717
+        DoCostPatch = True
+        DoMassPatch = True
+        TANK
+        {
+            name = LFO
+            Volume = 100.0
+        }
+    }
+	!RESOURCE[LiquidFuel] {}
+	!RESOURCE[Oxidizer] {}
+}


### PR DESCRIPTION
The title says it all. I needed CC/OPT integration for a career save, so I made it happen.

The style of the cfg does not really match your existing ones at all, but on the other hand, it's short and probably won't need to be updated if OPT adds/modifies parts.

It's up to you if you want to use it or not.