### PR TITLE
Get CKAN version data from version files

### DIFF
--- a/ConfigurableContainers-Core.netkan
+++ b/ConfigurableContainers-Core.netkan
@@ -3,7 +3,7 @@
     "identifier"   : "ConfigurableContainers-Core",
     "name"         : "Configurable Containers Core",
     "$kref"        : "#/ckan/spacedock/1002",
-    "$vref"        : "#/ckan/ksp-avc",
+    "$vref"        : "#/ckan/ksp-avc/ConfigurableContainers.version",
     "abstract"     : "This is the core configuration for the Configurable Containers.",
     "author"       : [ "allista" ],
     "license"      : "MIT",

--- a/ConfigurableContainers-Core.netkan
+++ b/ConfigurableContainers-Core.netkan
@@ -3,6 +3,7 @@
     "identifier"   : "ConfigurableContainers-Core",
     "name"         : "Configurable Containers Core",
     "$kref"        : "#/ckan/spacedock/1002",
+    "$vref"        : "#/ckan/ksp-avc",
     "abstract"     : "This is the core configuration for the Configurable Containers.",
     "author"       : [ "allista" ],
     "license"      : "MIT",

--- a/ConfigurableContainers.netkan
+++ b/ConfigurableContainers.netkan
@@ -2,6 +2,7 @@
     "spec_version" : "v1.4",
     "identifier"   : "ConfigurableContainers",
     "$kref"        : "#/ckan/spacedock/1002",
+    "$vref"        : "#/ckan/ksp-avc",
     "abstract"     : "This mod converts all the stock fuel tanks and resource containers so that you can change the resource(s) they hold in Editor and in Flight.",
     "author"       : [ "allista" ],
     "license"      : "MIT",


### PR DESCRIPTION
This mod contains a valid version file, which CKAN can use for compatibility info, but the metanetkan is currently not set up for this. (The impact is minor: CKAN has this as compatible only with 1.9.1 based on its SpaceDock info, but it should be marked as compatible with 1.9.0 as well.)

Now the version file will be used.